### PR TITLE
Adds vaadin 24 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.vaadin.componentfactory</groupId>
 	<artifactId>togglebutton-root</artifactId>
 	<packaging>pom</packaging>
-	<version>2.0.0</version>
+	<version>3.0.0-SNAPSHOT</version>
 
 	<name>Component Factory Toggle Button add-on Root</name>
 

--- a/togglebutton-demo/pom.xml
+++ b/togglebutton-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>togglebutton-demo</artifactId>
     <packaging>war</packaging>
-    <version>2.0.0</version>
+    <version>3.0.0-SNAPSHOT</version>
 
     <name>Component Factory Toggle Button add-on Demo</name>
 
@@ -18,13 +18,13 @@
 
     <properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
-        <vaadin.version>23.0.10</vaadin.version>
-        <flow.version>23.0.7</flow.version>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <vaadin.version>24.0.0</vaadin.version>
+        <flow.version>24.0.0</flow.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <jetty.version>9.4.36.v20210114</jetty.version>
+        <jetty.version>11.0.14</jetty.version>
     </properties>
 
     <dependencyManagement>

--- a/togglebutton-demo/src/main/java/com/vaadin/componentfactory/demo/ToggleButtonView.java
+++ b/togglebutton-demo/src/main/java/com/vaadin/componentfactory/demo/ToggleButtonView.java
@@ -53,8 +53,11 @@ public class ToggleButtonView extends DemoView {
         // source-example-heading: Disabled Toggle Button
         ToggleButton disabledToggle = new ToggleButton("Disabled");
         disabledToggle.setEnabled(false);
+        ToggleButton disabledToggleChecked = new ToggleButton("Disabled and checked");
+        disabledToggleChecked.setEnabled(false);
+        disabledToggleChecked.setValue(true);
         // end-source-example
-        addCard("Disabled Toggle Button", disabledToggle);
+        addCard("Disabled Toggle Button", disabledToggle, disabledToggleChecked);
     }
 
     private void exampleValueChangeListener() {

--- a/togglebutton/pom.xml
+++ b/togglebutton/pom.xml
@@ -3,15 +3,15 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>togglebutton</artifactId>
-    <version>2.0.0</version>
+    <version>3.0.0-SNAPSHOT</version>
     <name>ToggleButton for Flow</name>
     <description>Integration of vcf-toggle-button for Vaadin platform</description>
 
     <properties>
-        <vaadin.version>23.0.10</vaadin.version>
+        <vaadin.version>24.0.0</vaadin.version>
 
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/togglebutton/src/main/java/com/vaadin/componentfactory/ToggleButton.java
+++ b/togglebutton/src/main/java/com/vaadin/componentfactory/ToggleButton.java
@@ -30,7 +30,6 @@ import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.shared.Registration;
@@ -42,9 +41,8 @@ import com.vaadin.flow.shared.Registration;
  */
 
 @Tag("vcf-toggle-button")
-@NpmPackage(value = "@vaadin-component-factory/vcf-toggle-button", version = "1.0.3")
+@NpmPackage(value = "@vaadin-component-factory/vcf-toggle-button", version = "2.0.0-vaadin-24")
 @JsModule("@vaadin-component-factory/vcf-toggle-button")
-@CssImport(value = "./styles/vaadin-checkbox.css", themeFor = "vaadin-checkbox")
 @SuppressWarnings("serial")
 public class ToggleButton extends
         AbstractSinglePropertyField<ToggleButton, Boolean> implements HasStyle,

--- a/togglebutton/src/main/resources/META-INF/resources/frontend/styles/vaadin-checkbox.css
+++ b/togglebutton/src/main/resources/META-INF/resources/frontend/styles/vaadin-checkbox.css
@@ -1,8 +1,0 @@
-:host(.toggle-button) [part='checkbox']::after {
-    width: calc(1.2em - 4px);
-    height: calc(1.2em - 4px);
-}
-
-:host(.toggle-button[disabled]) [part='checkbox']::after {
-    color: transparent;
-}


### PR DESCRIPTION
Updates the vcf-toggle-button dependency to a version which supports vaadin 24 (it is not released yet).