### PR TITLE
Accessibility fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,10 @@ target/
 *.iml
 .idea/
 .eclipse
-
+.vscode/settings.json
+.settings
+.classpath
+.project
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
@@ -35,5 +38,9 @@ package-lock.json
 package.json
 webpack.config.js
 webpack.generated.js
+tsconfig.json
+types.d.ts
+togglebutton-demo/frontend/generated
+togglebutton-demo/frontend/index.html
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.vaadin.componentfactory</groupId>
 	<artifactId>togglebutton-root</artifactId>
 	<packaging>pom</packaging>
-	<version>1.0.1</version>
+	<version>1.0.2</version>
 
 	<name>Component Factory Toggle Button add-on Root</name>
 

--- a/togglebutton-demo/pom.xml
+++ b/togglebutton-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>togglebutton-demo</artifactId>
     <packaging>war</packaging>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 
     <name>Component Factory Toggle Button add-on Demo</name>
 

--- a/togglebutton-demo/pom.xml
+++ b/togglebutton-demo/pom.xml
@@ -18,8 +18,8 @@
 
     <properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
-        <vaadin.version>14.4.4</vaadin.version>
-        <flow.version>2.0.1</flow.version>
+        <vaadin.version>14.9.8</vaadin.version>
+        <flow.version>2.8.7</flow.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/togglebutton/pom.xml
+++ b/togglebutton/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>togglebutton</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <name>ToggleButton for Flow</name>
     <description>Integration of vcf-toggle-button for Vaadin platform</description>
 

--- a/togglebutton/src/main/java/com/vaadin/componentfactory/ToggleButton.java
+++ b/togglebutton/src/main/java/com/vaadin/componentfactory/ToggleButton.java
@@ -41,7 +41,7 @@ import com.vaadin.flow.shared.Registration;
  */
 
 @Tag("vcf-toggle-button")
-@NpmPackage(value = "@vaadin-component-factory/vcf-toggle-button", version = "1.0.3")
+@NpmPackage(value = "@vaadin-component-factory/vcf-toggle-button", version = "1.0.4")
 @JsModule("@vaadin-component-factory/vcf-toggle-button")
 @SuppressWarnings("serial")
 public class ToggleButton extends


### PR DESCRIPTION
Update web component version to 1.0.4 that includes fix that adds aria-label to label span to improve accessibility for screen readers.