### PR TITLE
feat: add LabelPosition enum (EAST/WEST/NORTH/SOUTH) for toggle label…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>togglebutton-root</artifactId>
-    <version>4.0.0</version>
+    <version>4.1.0</version>
     <packaging>pom</packaging>
 
     <name>Component Factory Toggle Button</name>

--- a/togglebutton-demo/pom.xml
+++ b/togglebutton-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>togglebutton-demo</artifactId>
     <packaging>war</packaging>
-    <version>4.0.0</version>
+    <version>4.1.0</version>
 
     <name>Component Factory Toggle Button add-on Demo</name>
 

--- a/togglebutton-demo/src/main/java/com/vaadin/componentfactory/demo/ToggleButtonDemoView.java
+++ b/togglebutton-demo/src/main/java/com/vaadin/componentfactory/demo/ToggleButtonDemoView.java
@@ -143,6 +143,30 @@ public class ToggleButtonDemoView extends VerticalLayout {
         disabledOn.setEnabled(false);
         panel.add(disabledOn);
 
+        for (ToggleButton.LabelPosition pos : new ToggleButton.LabelPosition[]{
+                ToggleButton.LabelPosition.WEST,
+                ToggleButton.LabelPosition.NORTH,
+                ToggleButton.LabelPosition.SOUTH}) {
+
+            panel.add(spacer());
+
+            H4 posHeading = new H4("Label " + pos.name().charAt(0) + pos.name().substring(1).toLowerCase());
+            posHeading.getStyle()
+                    .set("margin", "12px 0 12px 0")
+                    .set("font-size", "14px")
+                    .set("color", textColor);
+            panel.add(posHeading);
+
+            ToggleButton off = new ToggleButton("Off state");
+            off.setLabelPosition(pos);
+            panel.add(off);
+            panel.add(spacer());
+
+            ToggleButton on = new ToggleButton("On state", true);
+            on.setLabelPosition(pos);
+            panel.add(on);
+        }
+
         return panel;
     }
 

--- a/togglebutton/pom.xml
+++ b/togglebutton/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>togglebutton</artifactId>
-    <version>4.0.0</version>
+    <version>4.1.0</version>
     <name>ToggleButton for Flow</name>
     <description>Toggle Button component for Vaadin 25.0</description>
 

--- a/togglebutton/src/main/java/com/vaadin/componentfactory/ToggleButton.java
+++ b/togglebutton/src/main/java/com/vaadin/componentfactory/ToggleButton.java
@@ -90,6 +90,46 @@ public class ToggleButton extends Checkbox implements HasTheme {
         addThemeName();
     }
 
+    /**
+     * Defines where the label is placed relative to the toggle switch.
+     */
+    public enum LabelPosition {
+        /** Label to the right of the toggle (default). */
+        EAST,
+        /** Label to the left of the toggle. */
+        WEST,
+        /** Label above the toggle. */
+        NORTH,
+        /** Label below the toggle. */
+        SOUTH
+    }
+
+    /**
+     * Sets the position of the label relative to the toggle switch.
+     *
+     * @param position the label position; {@code null} resets to {@link LabelPosition#EAST}
+     */
+    public void setLabelPosition(LabelPosition position) {
+        removeThemeName("label-west");
+        removeThemeName("label-north");
+        removeThemeName("label-south");
+        if (position != null && position != LabelPosition.EAST) {
+            addThemeName("label-" + position.name().toLowerCase());
+        }
+    }
+
+    /**
+     * Returns the current label position.
+     *
+     * @return the label position, never {@code null}
+     */
+    public LabelPosition getLabelPosition() {
+        if (getThemeNames().contains("label-west"))  return LabelPosition.WEST;
+        if (getThemeNames().contains("label-north")) return LabelPosition.NORTH;
+        if (getThemeNames().contains("label-south")) return LabelPosition.SOUTH;
+        return LabelPosition.EAST;
+    }
+
     private void addThemeName() {
         addThemeName(THEME_NAME);
     }

--- a/togglebutton/src/main/resources/META-INF/resources/frontend/styles/vaadin-checkbox.css
+++ b/togglebutton/src/main/resources/META-INF/resources/frontend/styles/vaadin-checkbox.css
@@ -26,8 +26,8 @@ vaadin-checkbox[theme~="toggle-button"]::part(checkbox) {
     overflow: hidden;
     display: block;
     box-sizing: border-box;
-    /* Nudge up 1px to align with the optical (cap-height) centre of the label text */
-    translate: 0 -1px;
+    /* Nudge up 2px to align with the optical (cap-height) centre of the label text */
+    translate: 0 -2px;
 }
 
 /* Toggle knob */

--- a/togglebutton/src/main/resources/META-INF/resources/frontend/styles/vaadin-checkbox.css
+++ b/togglebutton/src/main/resources/META-INF/resources/frontend/styles/vaadin-checkbox.css
@@ -26,6 +26,8 @@ vaadin-checkbox[theme~="toggle-button"]::part(checkbox) {
     overflow: hidden;
     display: block;
     box-sizing: border-box;
+    /* Nudge up 1px to align with the optical (cap-height) centre of the label text */
+    translate: 0 -1px;
 }
 
 /* Toggle knob */

--- a/togglebutton/src/main/resources/META-INF/resources/frontend/styles/vaadin-checkbox.css
+++ b/togglebutton/src/main/resources/META-INF/resources/frontend/styles/vaadin-checkbox.css
@@ -6,6 +6,11 @@
  * When neither is loaded, hardcoded fallback values are used.
  */
 
+/* Vertically centre the label text with the toggle track */
+vaadin-checkbox[theme~="toggle-button"] {
+    align-items: center;
+}
+
 /* Toggle track */
 vaadin-checkbox[theme~="toggle-button"]::part(checkbox) {
     position: relative;

--- a/togglebutton/src/main/resources/META-INF/resources/frontend/styles/vaadin-checkbox.css
+++ b/togglebutton/src/main/resources/META-INF/resources/frontend/styles/vaadin-checkbox.css
@@ -72,3 +72,39 @@ vaadin-checkbox[checked][disabled][theme~="toggle-button"]::part(checkbox) {
     background-color: var(--lumo-primary-color, var(--aura-primary-color, #1676f3));
     opacity: 0.4;
 }
+
+/* WEST: label on left, toggle on right */
+vaadin-checkbox[theme~="toggle-button"][theme~="label-west"]::part(checkbox) {
+    grid-column: 2;
+}
+vaadin-checkbox[theme~="toggle-button"][theme~="label-west"]::part(label) {
+    grid-column: 1;
+}
+
+/* NORTH: label on top, toggle on bottom */
+vaadin-checkbox[theme~="toggle-button"][theme~="label-north"] {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+}
+vaadin-checkbox[theme~="toggle-button"][theme~="label-north"]::part(checkbox) {
+    order: 2;
+}
+vaadin-checkbox[theme~="toggle-button"][theme~="label-north"]::part(label) {
+    order: 1;
+}
+
+/* SOUTH: toggle on top, label on bottom */
+vaadin-checkbox[theme~="toggle-button"][theme~="label-south"] {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+}
+vaadin-checkbox[theme~="toggle-button"][theme~="label-south"]::part(checkbox) {
+    order: 1;
+}
+vaadin-checkbox[theme~="toggle-button"][theme~="label-south"]::part(label) {
+    order: 2;
+}


### PR DESCRIPTION
feat: add LabelPosition enum (EAST/WEST/NORTH/SOUTH) for toggle label placement

    Exposes setLabelPosition/getLabelPosition API on ToggleButton and
    extends the demo to show all three non-default positions.
