### PR TITLE
Restore CheckboxGroup support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ target/
 *.iml
 .idea/
 .eclipse
-
+.vscode
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
@@ -37,5 +37,11 @@ webpack.config.js
 webpack.generated.js
 
 
-/togglebutton-demo/frontend/generated/
+togglebutton-demo/src/main/frontend/index.html
 togglebutton-demo/src/main/frontend/generated/
+togglebutton-demo/src/main/bundles
+togglebutton-demo/.npmrc
+togglebutton-demo/tsconfig.json
+togglebutton-demo/types.d.ts
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>togglebutton-root</artifactId>
-    <version>4.2.0</version>
+    <version>4.2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Component Factory Toggle Button</name>

--- a/togglebutton-demo/pom.xml
+++ b/togglebutton-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>togglebutton-demo</artifactId>
     <packaging>war</packaging>
-    <version>4.2.0</version>
+    <version>4.2.1-SNAPSHOT</version>
 
     <name>Component Factory Toggle Button add-on Demo</name>
 

--- a/togglebutton-demo/src/main/java/com/vaadin/componentfactory/demo/ToggleButtonDemoView.java
+++ b/togglebutton-demo/src/main/java/com/vaadin/componentfactory/demo/ToggleButtonDemoView.java
@@ -5,6 +5,8 @@ import com.vaadin.componentfactory.ToggleButton.LabelPosition;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.checkbox.CheckboxGroup;
+import com.vaadin.flow.component.checkbox.CheckboxGroupVariant;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.html.H4;
@@ -219,6 +221,24 @@ public class ToggleButtonDemoView extends VerticalLayout {
             withError.setId("toggle-" + posKey + "-error-" + suffix);
             panel.add(withError);
         }
+
+        panel.add(spacer());
+
+        H4 groupHeading = new H4("CheckboxGroup");
+        groupHeading.getStyle()
+                .set("margin", "12px 0 12px 0")
+                .set("font-size", "14px")
+                .set("color", textColor);
+        panel.add(groupHeading);
+
+        CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
+        checkboxGroup.setLabel("Export data");
+        checkboxGroup.setItems("Order ID", "Product name", "Customer", "Status");
+        checkboxGroup.select("Order ID", "Customer");
+        checkboxGroup.addThemeVariants(CheckboxGroupVariant.LUMO_VERTICAL);
+        checkboxGroup.addThemeName(ToggleButton.THEME_NAME);
+        checkboxGroup.setId("toggle-checkbox-group-" + suffix);
+        panel.add(checkboxGroup);
 
         return panel;
     }

--- a/togglebutton/pom.xml
+++ b/togglebutton/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>togglebutton</artifactId>
-    <version>4.2.0</version>
+    <version>4.2.1-SNAPSHOT</version>
     <name>ToggleButton for Flow</name>
     <description>Toggle Button component for Vaadin 25.0</description>
 

--- a/togglebutton/src/main/resources/META-INF/resources/frontend/styles/vaadin-checkbox.css
+++ b/togglebutton/src/main/resources/META-INF/resources/frontend/styles/vaadin-checkbox.css
@@ -16,7 +16,8 @@
  *   3. color-mix fallback             – 60 % of currentColor, so it adapts to
  *      whatever text colour the surrounding context has inherited.
  */
-vaadin-checkbox[theme~="toggle-button"] {
+vaadin-checkbox[theme~="toggle-button"],
+vaadin-checkbox-group[theme~="toggle-button"] > vaadin-checkbox {
     align-items: center;
     --vaadin-input-field-error-color: var(--lumo-error-text-color, var(--aura-red-text, #b71c1c));
     --vaadin-input-field-helper-color: var(--vaadin-text-color-secondary, var(--lumo-secondary-text-color, color-mix(in srgb, currentColor 60%, transparent)));
@@ -34,12 +35,14 @@ vaadin-checkbox[theme~="toggle-button"] {
 /* Explicitly apply the helper colour via ::part() so it works in unstyled
  * mode (where no Lumo/Aura shadow-DOM rules are active) and overrides any
  * stale shadow-DOM internal colour when a theme IS loaded. */
-vaadin-checkbox[theme~="toggle-button"]::part(helper-text) {
+vaadin-checkbox[theme~="toggle-button"]::part(helper-text),
+vaadin-checkbox-group[theme~="toggle-button"] > vaadin-checkbox::part(helper-text) {
     color: var(--vaadin-input-field-helper-color);
 }
 
 /* Toggle track */
-vaadin-checkbox[theme~="toggle-button"]::part(checkbox) {
+vaadin-checkbox[theme~="toggle-button"]::part(checkbox),
+vaadin-checkbox-group[theme~="toggle-button"] > vaadin-checkbox::part(checkbox) {
     position: relative;
     width: 40px;
     height: 22px;
@@ -58,7 +61,8 @@ vaadin-checkbox[theme~="toggle-button"]::part(checkbox) {
 }
 
 /* Toggle knob */
-vaadin-checkbox[theme~="toggle-button"]::part(checkbox)::after {
+vaadin-checkbox[theme~="toggle-button"]::part(checkbox)::after,
+vaadin-checkbox-group[theme~="toggle-button"] > vaadin-checkbox::part(checkbox)::after {
     position: absolute !important;
     content: "" !important;
     inset: auto !important;
@@ -81,28 +85,33 @@ vaadin-checkbox[theme~="toggle-button"]::part(checkbox)::after {
 }
 
 /* Checked knob position */
-vaadin-checkbox[checked][theme~="toggle-button"]::part(checkbox)::after {
+vaadin-checkbox[checked][theme~="toggle-button"]::part(checkbox)::after,
+vaadin-checkbox-group[theme~="toggle-button"] > vaadin-checkbox[checked]::part(checkbox)::after {
     left: 21px !important;
 }
 
 /* Checked track color */
-vaadin-checkbox[checked][theme~="toggle-button"]::part(checkbox) {
+vaadin-checkbox[checked][theme~="toggle-button"]::part(checkbox),
+vaadin-checkbox-group[theme~="toggle-button"] > vaadin-checkbox[checked]::part(checkbox) {
     background-color: var(--lumo-primary-color, var(--aura-primary-color, #1676f3));
 }
 
 /* Disabled track */
-vaadin-checkbox[disabled][theme~="toggle-button"]::part(checkbox) {
+vaadin-checkbox[disabled][theme~="toggle-button"]::part(checkbox),
+vaadin-checkbox-group[theme~="toggle-button"] > vaadin-checkbox[disabled]::part(checkbox) {
     opacity: 0.5;
     cursor: default;
 }
 
 /* Disabled knob */
-vaadin-checkbox[disabled][theme~="toggle-button"]::part(checkbox)::after {
+vaadin-checkbox[disabled][theme~="toggle-button"]::part(checkbox)::after,
+vaadin-checkbox-group[theme~="toggle-button"] > vaadin-checkbox[disabled]::part(checkbox)::after {
     color: transparent !important;
 }
 
 /* Checked + disabled track */
-vaadin-checkbox[checked][disabled][theme~="toggle-button"]::part(checkbox) {
+vaadin-checkbox[checked][disabled][theme~="toggle-button"]::part(checkbox),
+vaadin-checkbox-group[theme~="toggle-button"] > vaadin-checkbox[checked][disabled]::part(checkbox) {
     background-color: var(--lumo-primary-color, var(--aura-primary-color, #1676f3));
     opacity: 0.4;
 }
@@ -208,6 +217,7 @@ vaadin-checkbox[theme~="toggle-button"][theme~="label-bottom"]::part(error-messa
     grid-row: auto;
 }
 
-vaadin-checkbox[theme~="toggle-button"]::before {
+vaadin-checkbox[theme~="toggle-button"]::before,
+vaadin-checkbox-group[theme~="toggle-button"] > vaadin-checkbox::before {
     display: none;
 }


### PR DESCRIPTION
This PR restores CheckboxGroup support. CSS selectors targeting `vaadin-checkbox-group[theme~="toggle-button"] > vaadin-checkbox` were removed in PR #23. These are required because `addThemeName()` sets the theme on the group element itself — it is not propagated to child vaadin-checkbox elements, so the individual `vaadin-checkbox[theme~="toggle-button"]` selectors never match.

This PR also restores the CheckboxGroup demo example that was removed in the same PR.

Version was updated to next snapshot: 4.2.1-SNAPSHOT and .gitignore was updated with missing rules.

_Note_: this fix was implemented together with ClaudeCode. AI generated code was manually reviewed by the author.

Close #27 